### PR TITLE
deprecation fixture methods

### DIFF
--- a/src/main/java/br/com/fixturefactory/Rule.java
+++ b/src/main/java/br/com/fixturefactory/Rule.java
@@ -43,10 +43,18 @@ public class Rule {
     	this.properties.add(new Property(property, function));
     }
 
+    /**
+     * @deprecated use {@link one(clazz, label)} instead.
+     */
+    @Deprecated
 	public Function fixture(Class<?> clazz, String label) {
     	return new FixtureFunction(clazz, label);
     }
 
+    /**
+     * @deprecated use {@link has(quantity).of(clazz, label)} instead.
+     */
+    @Deprecated
 	public Function fixture(Class<?> clazz, Integer quantity, String label) {
     	return new FixtureFunction(clazz, label, quantity);
     }


### PR DESCRIPTION
Deprecation of fixture methods used in relationships.
Use one() and has() instead.
