### PR TITLE
better error message for attributes that were not found

### DIFF
--- a/src/main/java/br/com/fixturefactory/util/ReflectionUtils.java
+++ b/src/main/java/br/com/fixturefactory/util/ReflectionUtils.java
@@ -58,7 +58,7 @@ public class ReflectionUtils {
             getPropertyUtilsBean().setProperty(bean, attribute, value);
         } catch (Exception ex){
             if(fail) {
-                throw new IllegalArgumentException("No such attribute: " + attribute);
+                throw new IllegalArgumentException(bean.getClass().getCanonicalName() + "-> No such attribute: " + attribute + "[" + value.getClass().getName() + "]");
             }
         }   
     }


### PR DESCRIPTION
Better exception trace describing the fixture class, attribute and attribute type that throws the error.

<pre>
java.lang.IllegalArgumentException: br.com.fixturefactory.model.Client-> No such attribute: id[java.lang.Integer]
</pre>
