### PR TITLE
Added a cache for factories requested in Fixture.from static method.

### DIFF
--- a/src/main/java/br/com/six2six/fixturefactory/Fixture.java
+++ b/src/main/java/br/com/six2six/fixturefactory/Fixture.java
@@ -5,11 +5,11 @@ import java.util.Map;
 
 public class Fixture {
 
-	private static Map<Class<?>, TemplateHolder> templates = new LinkedHashMap<Class<?>, TemplateHolder>();
-	
+	private static final Map<Class<?>, TemplateHolder> templates = new LinkedHashMap<Class<?>, TemplateHolder>();
+	private static final Map<Class<?>, ObjectFactory> factories = new LinkedHashMap<Class<?>, ObjectFactory>();
+
 	public static TemplateHolder of(Class<?> clazz) {
 		TemplateHolder template = templates.get(clazz);
-		
 		if (template == null) {
 			template = new TemplateHolder(clazz);
 			templates.put(clazz, template);
@@ -17,8 +17,14 @@ public class Fixture {
 
 		return template;
 	}
-	
+
 	public static ObjectFactory from(Class<?> clazz) {
-		return new ObjectFactory(of(clazz));
+		ObjectFactory factory = factories.get(clazz);
+		if (factory == null) {
+			factory = new ObjectFactory(of(clazz));
+			factories.put(clazz, factory);
+		}
+
+		return factory;
 	}
 }


### PR DESCRIPTION
A `ObjectFactory` operates like a singleton for each class when was created in `Fixture.from` static method. Example:

``` java
Entity e1 = Fixture.from(Entity.class).gimme("valid");
Entity e2 = Fixture.from(Entity.class).gimme("valid");
```

This snippet call a `Fixture.from` method twice and create two `ObjectFactory` for two diferent fixtures from `Entity`. Two identical factory was created under the same `TemplateHolder` object provided by templates map in `Fixture` class. Even with no expansive computations theres no need to create a `ObjectFactory` in each call of `Fixture.from`. With this modification, a single `ObjectFactory` is created and two different fixtures for the `Entity` class.
