### PR TITLE
fixing template where we want to override nested attribute value

### DIFF
--- a/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
+++ b/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -88,7 +89,7 @@ public class ObjectFactory {
 	}
 
 	protected Object createObject(Rule rule) {
-		Map<String, Object> constructorArguments = new HashMap<String, Object>();
+		Map<String, Property> constructorArguments = new HashMap<String, Property>();
 		List<Property> deferredProperties = new ArrayList<Property>();
 		Class<?> clazz = templateHolder.getClazz();
 		
@@ -96,14 +97,19 @@ public class ObjectFactory {
 										lookupConstructorParameterNames(clazz, rule.getProperties()) : new ArrayList<String>();
 		
 		for (Property property : rule.getProperties()) {
-			if (parameterNames.contains(property.getRootAttribute())) {
-				constructorArguments.put(property.getName(), generateConstructorParamValue(property));
+			if(parameterNames.contains(property.getRootAttribute())) {
+				constructorArguments.put(property.getName(), property);
 			} else {
 				deferredProperties.add(property);
 			}
 		}
 		
 		Object result = ReflectionUtils.newInstance(clazz, processConstructorArguments(parameterNames, constructorArguments));
+		
+		Set<Property> propertiesNotUsedInConstructor = getPropertiesNotUsedInConstructor(constructorArguments, parameterNames);
+		if(propertiesNotUsedInConstructor.size() > 0) {
+			deferredProperties.addAll(propertiesNotUsedInConstructor);
+		}
 		
 		for (Property property : deferredProperties) {
 			ReflectionUtils.invokeRecursiveSetter(result, property.getName(), processPropertyValue(result, property));
@@ -113,6 +119,16 @@ public class ObjectFactory {
 		    processor.execute(result);
 		}
 		return result;
+	}
+
+	private Set<Property> getPropertiesNotUsedInConstructor(Map<String, Property> constructorArguments, List<String> parameterNames) {
+		Set<Property> propertiesNotUsedInConstructor = new HashSet<Property>(constructorArguments.values());
+		Set<Property> parameterProperties = new HashSet<Property>();
+		for(String parameterName : parameterNames) {
+			parameterProperties.add(new Property(parameterName, "fakeValue"));
+		}
+		propertiesNotUsedInConstructor.removeAll(parameterProperties);
+		return propertiesNotUsedInConstructor;
 	}
 	
 	@SuppressWarnings("unchecked")
@@ -166,24 +182,34 @@ public class ObjectFactory {
 	    }
 	}
 
-	protected List<Object> processConstructorArguments(List<String> parameterNames, Map<String, Object> arguments) {
+	protected List<Object> processConstructorArguments(List<String> parameterNames, Map<String, Property> arguments) {
 		List<Object> values = new ArrayList<Object>();
+		Map<String, Object> processedArguments = processArguments(arguments); 
 		
 		if (owner != null && ReflectionUtils.isInnerClass(templateHolder.getClazz()))  {
 			values.add(owner);	
 		}
 		
-        TransformerChain transformerChain = buildTransformerChain(new ParameterPlaceholderTransformer(arguments));
+        TransformerChain transformerChain = buildTransformerChain(new ParameterPlaceholderTransformer(processedArguments));
 		
 		for (String parameterName : parameterNames) {
 			Class<?> fieldType = ReflectionUtils.invokeRecursiveType(templateHolder.getClazz(), parameterName);
-			Object result = arguments.get(parameterName);
+			Object result = processedArguments.get(parameterName);
 			if (result == null) {
-				result = processChainedProperty(parameterName, fieldType, arguments);	
+				result = processChainedProperty(parameterName, fieldType, processedArguments);	
 			}
 			values.add(transformerChain.transform(result, fieldType));
 		}
 		return values;
+	}
+	
+	private Map<String, Object> processArguments(Map<String, Property> arguments) {
+		Map<String, Object> processedArguments = new HashMap<String, Object>();
+		for(String key : arguments.keySet()) {
+			processedArguments.put(key, generateConstructorParamValue(arguments.get(key)));
+		}
+		
+		return processedArguments;
 	}
 
 	protected Object processChainedProperty(String parameterName, Class<?> fieldType, Map<String, Object> arguments) {

--- a/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
+++ b/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 
 import org.apache.commons.lang.StringUtils;
@@ -203,8 +204,8 @@ public class ObjectFactory {
 	
 	private Map<String, Object> processArguments(Map<String, Property> arguments) {
 		Map<String, Object> processedArguments = new HashMap<String, Object>();
-		for(String key : arguments.keySet()) {
-			processedArguments.put(key, generateConstructorParamValue(arguments.get(key)));
+		for(Entry<String, Property> entry : arguments.entrySet()) {
+			processedArguments.put(entry.getKey(), generateConstructorParamValue(entry.getValue()));
 		}
 		
 		return processedArguments;

--- a/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
+++ b/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
@@ -122,13 +122,11 @@ public class ObjectFactory {
 	}
 
 	private Set<Property> getPropertiesNotUsedInConstructor(Map<String, Property> constructorArguments, List<String> parameterNames) {
-		Set<Property> propertiesNotUsedInConstructor = new HashSet<Property>(constructorArguments.values());
-		Set<Property> parameterProperties = new HashSet<Property>();
+		Map<String, Property> propertiesNotUsedInConstructor = new HashMap<String, Property>(constructorArguments);
 		for(String parameterName : parameterNames) {
-			parameterProperties.add(new Property(parameterName, "fakeValue"));
+			propertiesNotUsedInConstructor.remove(parameterName);
 		}
-		propertiesNotUsedInConstructor.removeAll(parameterProperties);
-		return propertiesNotUsedInConstructor;
+		return new HashSet<Property>(propertiesNotUsedInConstructor.values());
 	}
 	
 	@SuppressWarnings("unchecked")

--- a/src/test/java/br/com/six2six/fixturefactory/FixtureImmutableTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/FixtureImmutableTest.java
@@ -96,4 +96,14 @@ public class FixtureImmutableTest {
         assertThat(child.getParentAttribute().getValue().length(), is(8));
         assertThat(child.getChildAttribute().length(), is(16));
     }
+    
+    @Test
+    public void shouldOverrideNestedObjectAttribute() {
+    	Immutable result = Fixture.from(Immutable.class).gimme("fullConstructor", new Rule() {{
+    		add("address.street", "Rua do Nykolas");
+    	}});
+    	
+    	assertThat(result.getAddress().getStreet(), equalTo("Rua do Nykolas"));
+    }
+    
 }


### PR DESCRIPTION
In immutable objects, when we try to override a nested attribute in the `gimme` call it doesn't work.

Now, after create the object with all property definitions, we take the properties that were not used in the constructor and starting processing then as deferred properties.

@ahirata @aparra can you guys review it please?

After merging it I'm going to release a fix version `2.2.1`