### PR TITLE
Fix timezone issues when 'mvn test'

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,6 +153,16 @@
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.18.1</version>
+                <configuration>
+                    <systemPropertyVariables>
+                        <user.timezone>UTC</user.timezone>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
Fixed failing test in current master by fixing the test timezone.

Failed tests:   testChronic(br.com.six2six.fixturefactory.function.ChronicFunctionTest): expected:<Sun Oct 30 12:00:00 GMT 2011> but was:<Sun Oct 30 11:30:00 GMT 2011>

Tests run: 148, Failures: 1, Errors: 0, Skipped: 0

