### PR TITLE
squid:S1118 - Utility classes should not have public constructors

### DIFF
--- a/src/main/java/br/com/six2six/fixturefactory/Fixture.java
+++ b/src/main/java/br/com/six2six/fixturefactory/Fixture.java
@@ -3,7 +3,11 @@ package br.com.six2six.fixturefactory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
-public class Fixture {
+public final class Fixture {
+
+	private Fixture() throws InstantiationException {
+		throw new InstantiationException("The class can't be instantiated");
+	}
 
 	private static Map<Class<?>, TemplateHolder> templates = new LinkedHashMap<Class<?>, TemplateHolder>();
 	

--- a/src/main/java/br/com/six2six/fixturefactory/loader/FixtureFactoryLoader.java
+++ b/src/main/java/br/com/six2six/fixturefactory/loader/FixtureFactoryLoader.java
@@ -2,7 +2,11 @@ package br.com.six2six.fixturefactory.loader;
 
 import static br.com.six2six.fixturefactory.util.ClassLoaderUtils.getClassesForPackage;
 
-public class FixtureFactoryLoader {
+public final class FixtureFactoryLoader {
+
+    private FixtureFactoryLoader() throws InstantiationException {
+        throw new InstantiationException("The class can't be instantiated");
+    }
 
 	public static void loadTemplates(String basePackage) {
         for (Class<?> clazz : getClassesForPackage(basePackage)) {

--- a/src/main/java/br/com/six2six/fixturefactory/util/ClassLoaderUtils.java
+++ b/src/main/java/br/com/six2six/fixturefactory/util/ClassLoaderUtils.java
@@ -11,7 +11,11 @@ import java.util.Set;
 import java.util.jar.JarEntry;
 import java.util.jar.JarInputStream;
 
-public class ClassLoaderUtils {
+public final class ClassLoaderUtils {
+
+	private ClassLoaderUtils() throws InstantiationException {
+		throw new InstantiationException("The class can't be instantiated");
+	}
 
 	public static Set<Class<?>> getClassesForPackage(String packageName) {
 		Set<Class<?>> classes = new HashSet<Class<?>>();

--- a/src/main/java/br/com/six2six/fixturefactory/util/DateTimeUtils.java
+++ b/src/main/java/br/com/six2six/fixturefactory/util/DateTimeUtils.java
@@ -4,7 +4,11 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.Calendar;
 
-public class DateTimeUtils {
+public final class DateTimeUtils {
+
+	private DateTimeUtils() throws InstantiationException {
+		throw new InstantiationException("The class can't be instantiated");		
+	}
 
 	public static Calendar toCalendar(String source, DateFormat format) {
 		Calendar date = Calendar.getInstance();

--- a/src/main/java/br/com/six2six/fixturefactory/util/ReflectionUtils.java
+++ b/src/main/java/br/com/six2six/fixturefactory/util/ReflectionUtils.java
@@ -20,11 +20,15 @@ import org.apache.commons.lang.StringUtils;
 import com.thoughtworks.paranamer.AdaptiveParanamer;
 import com.thoughtworks.paranamer.Paranamer;
 
-public class ReflectionUtils {
+public final class ReflectionUtils {
 
     public static final String CGLIB_CLASS_SEPARATOR = "$$";
     private static final String NO_SUCH_ATTRIBUTE_MESSAGE = "%s-> No such attribute: %s[%s]";
-    
+
+    private ReflectionUtils() throws InstantiationException {
+        throw new InstantiationException("The class can't be instantiated");
+    }
+
     @SuppressWarnings("unchecked")
     public static <T> T cast(Object source){
         try {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule squid:S1118 - Utility classes should not have public constructors

You can find more information about the issue here: https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118

Please let me know if you have any questions.

M-Ezzat