### PR TITLE
Support jdk8 classes using lambdas

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+[*.java]
+indent_style = space
+indent_size = 4

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
 		<dependency>
 			<groupId>com.thoughtworks.paranamer</groupId>
 			<artifactId>paranamer</artifactId>
-			<version>2.5</version>
+			<version>2.8</version>
 		</dependency>
 		<dependency>
 			<groupId>net.vidageek</groupId>
@@ -132,8 +132,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>2.3.2</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>${java.version}</source>
+					<target>${java.version}</target>
 					<encoding>UTF-8</encoding>
 				</configuration>
 			</plugin>
@@ -189,6 +189,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compile.encoding>UTF-8</maven.compile.encoding>
         <hamcrest.version>1.3</hamcrest.version>
+		<java.version>1.8</java.version>
 	</properties>
 
 </project>

--- a/src/test/java/br/com/six2six/fixturefactory/FixtureLambdaPlaneTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/FixtureLambdaPlaneTest.java
@@ -1,0 +1,27 @@
+package br.com.six2six.fixturefactory;
+
+import br.com.six2six.fixturefactory.loader.FixtureFactoryLoader;
+import br.com.six2six.fixturefactory.model.LambdaPlane;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.notNullValue;
+
+public class FixtureLambdaPlaneTest {
+
+    @BeforeClass
+    public static void beforeClass() {
+        FixtureFactoryLoader.loadTemplates("br.com.six2six.template");
+    }
+
+    @Test
+    public void shouldCreateInstanceInClassUsingLambda() throws Exception {
+        LambdaPlane validPlane = Fixture.from(LambdaPlane.class).gimme("valid");
+
+        assertThat(validPlane, is( notNullValue()) );
+        assertThat(validPlane.getFlightCrew().size(), is(equalTo( 3 )));
+    }
+}

--- a/src/test/java/br/com/six2six/fixturefactory/function/NumberSequenceFunctionTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/function/NumberSequenceFunctionTest.java
@@ -1,47 +1,53 @@
 package br.com.six2six.fixturefactory.function;
 
-import static org.junit.Assert.assertEquals;
-
-import org.junit.Test;
-
 import br.com.six2six.fixturefactory.function.impl.NumberSequence;
 import br.com.six2six.fixturefactory.function.impl.SequenceFunction;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
 
 public class NumberSequenceFunctionTest {
 
-	@Test
-	public void intSequence() {
-		SequenceFunction function = new SequenceFunction(new NumberSequence(0, 1));
-		
-		for (int i=0; i<3; i++) {
-			assertEquals("integers should be equal", function.generateValue(), i);
-		}
-	}
-	
-	@Test
-	public void longSequence() {
-		SequenceFunction function = new SequenceFunction(new NumberSequence(1L, 2));
-		
-		for (int i=1; i<=5; i=i+2) {
-			assertEquals("longs should be equal", function.generateValue(), (long) i);
-		}
-	}
-	
-	@Test
-	public void floatSequence() {
-		SequenceFunction function = new SequenceFunction(new NumberSequence(1.2f, 1));
-		
-		for (int i=1; i<=3; i++) {
-			assertEquals("floats should be equal", function.generateValue(), (float) i+(.2F));
-		}
-	}
-	
-	@Test
-	public void doubleSequence() {
-		SequenceFunction function = new SequenceFunction(new NumberSequence(1.23d, 2));
-		
-		for (int i=1; i<=5; i=i+2) {
-			assertEquals("doubles should be equal", function.generateValue(), (double) i+(.23d));
-		}
-	}
+    @Test
+    public void intSequence() {
+        SequenceFunction function = new SequenceFunction(new NumberSequence(0, 1));
+
+        for (int i = 0; i < 3; i++) {
+            assertEquals("integers should be equal", (int) function.generateValue(), i);
+        }
+    }
+
+    @Test
+    public void longSequence() {
+        SequenceFunction function = new SequenceFunction(new NumberSequence(1L, 2));
+
+        for (int i = 1; i <= 5; i = i + 2) {
+            assertEquals("longs should be equal", (long) function.generateValue(), (long) i);
+        }
+    }
+
+    @Test
+    public void floatSequence() {
+        SequenceFunction function = new SequenceFunction(new NumberSequence(1.2f, 1));
+
+        for (int i = 1; i <= 3; i++) {
+            assertEquals("floats should be equal",
+                (float) function.generateValue(),
+                (float) i + (.2F),
+                0.001
+            );
+        }
+    }
+
+    @Test
+    public void doubleSequence() {
+        SequenceFunction function = new SequenceFunction(new NumberSequence(1.23d, 2));
+
+        for (int i = 1; i <= 5; i = i + 2) {
+            assertEquals("doubles should be equal",
+                function.generateValue(),
+                (double) i + (.23d),
+                0.001);
+        }
+    }
 }

--- a/src/test/java/br/com/six2six/fixturefactory/model/Aircrew.java
+++ b/src/test/java/br/com/six2six/fixturefactory/model/Aircrew.java
@@ -1,0 +1,13 @@
+package br.com.six2six.fixturefactory.model;
+
+public class Aircrew {
+    private String name;
+
+    public Aircrew(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/src/test/java/br/com/six2six/fixturefactory/model/LambdaPlane.java
+++ b/src/test/java/br/com/six2six/fixturefactory/model/LambdaPlane.java
@@ -1,0 +1,36 @@
+package br.com.six2six.fixturefactory.model;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class LambdaPlane {
+
+    private String tailNumber;
+    private List<String> flightCrew;
+
+    public LambdaPlane(String tailNumber, List<String> flightCrew) {
+        this.tailNumber = tailNumber;
+        this.flightCrew = flightCrew;
+    }
+
+    public String getTailNumber() {
+        return tailNumber;
+    }
+
+    public List<String> getFlightCrew() {
+        return flightCrew;
+    }
+
+    @Override
+    public String toString() {
+        return "LambdaPlane{" +
+            "tailNumber='" + tailNumber + '\'' +
+            ", flightCrew=" +
+            flightCrew.stream()
+                .map(p -> "Emp: " + p)
+                .sorted()
+                .collect(Collectors.joining(", "))
+            +
+            '}';
+    }
+}

--- a/src/test/java/br/com/six2six/template/AircrewTemplate.java
+++ b/src/test/java/br/com/six2six/template/AircrewTemplate.java
@@ -1,0 +1,17 @@
+package br.com.six2six.template;
+
+
+import br.com.six2six.fixturefactory.Fixture;
+import br.com.six2six.fixturefactory.Rule;
+import br.com.six2six.fixturefactory.loader.TemplateLoader;
+import br.com.six2six.fixturefactory.model.Aircrew;
+
+public class AircrewTemplate implements TemplateLoader {
+
+    @Override
+    public void load() {
+        Fixture.of(Aircrew.class).addTemplate("random", new Rule(){{
+            add("name", firstName());
+        }});
+    }
+}

--- a/src/test/java/br/com/six2six/template/LambdaPlaneTemplate.java
+++ b/src/test/java/br/com/six2six/template/LambdaPlaneTemplate.java
@@ -1,0 +1,19 @@
+package br.com.six2six.template;
+
+import br.com.six2six.fixturefactory.Fixture;
+import br.com.six2six.fixturefactory.Rule;
+import br.com.six2six.fixturefactory.loader.TemplateLoader;
+import br.com.six2six.fixturefactory.model.Aircrew;
+import br.com.six2six.fixturefactory.model.LambdaPlane;
+
+public class LambdaPlaneTemplate implements TemplateLoader {
+
+
+    @Override
+    public void load() {
+        Fixture.of(LambdaPlane.class).addTemplate("valid", new Rule(){{
+            add("tailNumber", "A6-EDY");
+            add("flightCrew", has(3).of(Aircrew.class, "random"));
+        }});
+    }
+}


### PR DESCRIPTION
This PR is being submitted as means to solve issue #90. A quick summary of what I did in the PR:
1. Upgraded Paranamer library to 2.8
2. Moved target and sorce java version to 1.8 (JDK 8) to use lambdas in tests.
3. Added tests to make sure that classes with lambda expressions will work with fixture-factory.

If I am supposed to do improvements or fix any kind of error let me know.
