### PR TITLE
Include correct type of instance for all types of set trasform

### DIFF
--- a/src/main/java/br/com/six2six/fixturefactory/transformer/SetTransformer.java
+++ b/src/main/java/br/com/six2six/fixturefactory/transformer/SetTransformer.java
@@ -2,13 +2,19 @@ package br.com.six2six.fixturefactory.transformer;
 
 import java.util.Collection;
 import java.util.HashSet;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.SortedSet;
+import java.util.TreeSet;
 
 public class SetTransformer implements Transformer {
 
     @SuppressWarnings({ "rawtypes", "unchecked" })
     public <T> T transform(Object value, Class<T> type) {
-        return type.cast(new HashSet((Collection) value));
+    	if (SortedSet.class.isAssignableFrom(type) || NavigableSet.class.isAssignableFrom(type)) {
+    		return type.cast(new TreeSet((Collection) value));
+    	}
+    	return type.cast(new HashSet((Collection) value));
     }
 
     public boolean accepts(Object value, Class<?> type) {

--- a/src/test/java/br/com/six2six/fixturefactory/transformer/SetTransformerTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/transformer/SetTransformerTest.java
@@ -9,34 +9,60 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.NavigableSet;
 import java.util.Set;
+import java.util.SortedSet;
 
 import org.junit.Test;
 
 public class SetTransformerTest {
-    
-    @Test
-    public void shouldNotAcceptNonCollectionValue() {
-        assertFalse(new SetTransformer().accepts(new HashMap<String, Object>(), Set.class));
-    }
-    
-    @Test
-    public void shoudNotAcceptNonSetTarget() {
-        assertFalse(new SetTransformer().accepts(new ArrayList<String>(), LinkedList.class));
-    }
-    
-    @Test
-    public void shouldAcceptCollectionToSet() {
-        assertTrue(new SetTransformer().accepts(Arrays.asList("A", "B"), Set.class));        
-    }
 
-    @Test
-    @SuppressWarnings("unchecked")
-    public void shoudTransformToSet() {
-        List<String> value = Arrays.asList("A", "B");
-        Set<String> result = new SetTransformer().transform(value, Set.class);
-        
-        assertTrue(result.containsAll(value));
-        assertEquals(2, result.size());
-    }
+	@Test
+	public void shouldNotAcceptNonCollectionValue() {
+		assertFalse(new SetTransformer().accepts(new HashMap<String, Object>(), Set.class));
+	}
+
+	@Test
+	public void shoudNotAcceptNonSetTarget() {
+		assertFalse(new SetTransformer().accepts(new ArrayList<String>(), LinkedList.class));
+	}
+
+	@Test
+	public void shouldAcceptCollectionToSet() {
+		assertTrue(new SetTransformer().accepts(Arrays.asList("A", "B"), Set.class));
+	}
+
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shoudTransformToSet() {
+		List<String> value = Arrays.asList("A", "B");
+		Set<String> resultSet = new SetTransformer().transform(Arrays.asList("A", "B"),	Set.class);
+
+		assertTrue(resultSet.containsAll(value));
+		assertEquals(2, resultSet.size());
+		
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shoudTransformToNavigableSet() {
+		List<String> value = Arrays.asList("A", "B");
+		NavigableSet<String> resultNavigableSet = new SetTransformer().transform(Arrays.asList("A", "B"), NavigableSet.class);
+		
+		assertTrue(resultNavigableSet.containsAll(value));
+		assertEquals(2, resultNavigableSet.size());
+		
+	}
+	
+	@Test
+	@SuppressWarnings("unchecked")
+	public void shoudTransformToSortedSet() {
+		List<String> value = Arrays.asList("A", "B");
+		SortedSet<String> resultSortedSet = new SetTransformer().transform(Arrays.asList("A", "B"),	SortedSet.class);
+		
+		assertTrue(resultSortedSet.containsAll(value));
+		assertEquals(2, resultSortedSet.size());
+		
+	}
+
 }


### PR DESCRIPTION
Using has(1).of(Type) when the type is a SortedSet, an java.lang.ClassCastException: Cannot cast java.util.HashSet to java.util.SortedSet is throw.