### PR TITLE
Add method unique random for Long type

### DIFF
--- a/src/main/java/br/com/six2six/fixturefactory/Rule.java
+++ b/src/main/java/br/com/six2six/fixturefactory/Rule.java
@@ -109,6 +109,10 @@ public class Rule {
 		return new UniqueRandomFunction(minValue, maxValue);
 	}
 	
+	public <T> Function uniqueRandom(int minValue, int maxValue, Class<? extends Number> clazz) {
+		return new UniqueRandomFunction(minValue, maxValue, clazz);
+	}
+	
 	public Function uniqueRandom(Object... dataset) {
 		return new UniqueRandomFunction(dataset);
 	}

--- a/src/main/java/br/com/six2six/fixturefactory/function/impl/UniqueRandomFunction.java
+++ b/src/main/java/br/com/six2six/fixturefactory/function/impl/UniqueRandomFunction.java
@@ -18,6 +18,14 @@ public class UniqueRandomFunction implements AtomicFunction{
 		this.shuffleDataset();
 	}
 	
+	public UniqueRandomFunction(int minValue, int maxValue, Class<? extends Number> clazz) {
+		if(minValue >= maxValue) {
+			throw new IllegalArgumentException("maxValue cannot be greater than minValue.");
+		}
+		this.dataset = this.initNumberDataset(minValue, maxValue, clazz);
+		this.shuffleDataset();
+	}
+	
 	public UniqueRandomFunction(Object[] dataset) {
 		if(dataset.length == 0) {
 			throw new IllegalArgumentException("provided dataset has no elements.");
@@ -39,6 +47,29 @@ public class UniqueRandomFunction implements AtomicFunction{
 		int currValue = minValue;
 		for(int i = 0; i < dataset.length; i++) {
 			dataset[i] = currValue;
+			currValue ++;
+		}
+		
+		return dataset;
+	}
+	
+	private Object[] initNumberDataset(int minValue, int maxValue, Class<? extends Number> clazz) {
+		Number[] dataset;
+		if(clazz.equals(Integer.class)) {
+			dataset = new Integer[maxValue - minValue + 1];
+		}else if(clazz.equals(Long.class)) {
+			dataset = new Long[maxValue - minValue + 1];
+		}else {
+			throw new IllegalArgumentException("must be chosen between Integer or Long as type argument.");
+		}
+		
+		Integer currValue = minValue;
+		for(int i = 0; i < dataset.length; i++) {
+			if(clazz.equals(Integer.class)) {
+				dataset[i] = currValue;
+			}else {
+				dataset[i] = currValue.longValue();
+			}
 			currValue ++;
 		}
 		

--- a/src/test/java/br/com/six2six/fixturefactory/FixturePeopleTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/FixturePeopleTest.java
@@ -1,0 +1,28 @@
+package br.com.six2six.fixturefactory;
+
+import static org.junit.Assert.assertNotNull;
+
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import br.com.six2six.fixturefactory.loader.FixtureFactoryLoader;
+import br.com.six2six.fixturefactory.model.People;
+
+public class FixturePeopleTest {
+
+	@BeforeClass
+	public static void setUp() {
+		FixtureFactoryLoader.loadTemplates("br.com.six2six.template");
+	}
+	
+	@Test
+	public void fixtureClient() {
+		People people = Fixture.from(People.class).gimme("random");
+		assertNotNull("People should not be null", people);
+		assertNotNull("Name should not be null", people.getName());
+		assertNotNull("Age should not be null", people.getAge());
+		assertNotNull("Doc should not be null", people.getDoc());
+		assertNotNull("Borth should not be null", people.getBirth());
+	}
+
+}

--- a/src/test/java/br/com/six2six/fixturefactory/model/People.java
+++ b/src/test/java/br/com/six2six/fixturefactory/model/People.java
@@ -1,0 +1,50 @@
+package br.com.six2six.fixturefactory.model;
+
+import java.io.Serializable;
+import java.time.LocalDate;
+
+public class People implements Serializable{
+
+	private static final long serialVersionUID = -9071464054942141370L;
+
+	private Integer age;
+	
+	private Long doc;
+	
+	private String name;
+	
+	private LocalDate birth;
+
+	public Integer getAge() {
+		return age;
+	}
+
+	public void setAge(Integer age) {
+		this.age = age;
+	}
+
+	public Long getDoc() {
+		return doc;
+	}
+
+	public void setDoc(Long doc) {
+		this.doc = doc;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public LocalDate getBirth() {
+		return birth;
+	}
+
+	public void setBirth(LocalDate birth) {
+		this.birth = birth;
+	}
+	
+}

--- a/src/test/java/br/com/six2six/template/PeopleTemplate.java
+++ b/src/test/java/br/com/six2six/template/PeopleTemplate.java
@@ -1,0 +1,20 @@
+package br.com.six2six.template;
+
+import java.text.SimpleDateFormat;
+
+import br.com.six2six.fixturefactory.Fixture;
+import br.com.six2six.fixturefactory.Rule;
+import br.com.six2six.fixturefactory.loader.TemplateLoader;
+import br.com.six2six.fixturefactory.model.People;
+
+public class PeopleTemplate implements TemplateLoader {
+    @Override
+    public void load() {
+        Fixture.of(People.class).addTemplate("random", new Rule(){{
+            add("age", uniqueRandom(1, 20, Integer.class));
+            add("doc", uniqueRandom(1, 20, Long.class));
+            add("name", firstName());
+            add("birth", randomDate("1996-03-30", "2018-11-03", new SimpleDateFormat("yyyy-MM-dd")));
+        }});
+    }
+}


### PR DESCRIPTION
Many entities have the Long type identifier, and when creating tests, i needed to create identifiers with single IDs, but the uniqueRandom() method returns ever Integer type, making my tests not work.