### PR TITLE
Fixing generic inference, fixing JavaVersion parse for early access JVMs

### DIFF
--- a/src/main/java/br/com/six2six/fixturefactory/Fixture.java
+++ b/src/main/java/br/com/six2six/fixturefactory/Fixture.java
@@ -18,7 +18,7 @@ public class Fixture {
 		return template;
 	}
 	
-	public static ObjectFactory from(Class<?> clazz) {
-		return new ObjectFactory(of(clazz));
+	public static<T> ObjectFactory<T> from(Class<T> clazz) {
+		return new ObjectFactory<T>(of(clazz));
 	}
 }

--- a/src/main/java/br/com/six2six/fixturefactory/JavaVersion.java
+++ b/src/main/java/br/com/six2six/fixturefactory/JavaVersion.java
@@ -1,22 +1,34 @@
 package br.com.six2six.fixturefactory;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang.Validate;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 public class JavaVersion {
 
 	public static final JavaVersion JAVA_8 = new JavaVersion("1.8");
 	public static final JavaVersion JAVA_7 = new JavaVersion("1.7");
 	public static final JavaVersion JAVA_6 = new JavaVersion("1.6");
-	
-	private int major;
-	private int minor;
+
+	private Pattern JVM_VERSION_REGEX = Pattern.compile("(\\d+)[-.](\\d*)");
+
+	private final int major;
+	private final int minor;
+	private final double version;
 
 	public JavaVersion(String version) {
-	    String[] fields = version.split("\\.");
-	    this.major = Integer.parseInt(fields[0]);
-	    this.minor = Integer.parseInt(fields[1]);
+		final Matcher matcher = JVM_VERSION_REGEX.matcher(version);
+		Validate.isTrue(matcher.find(), "Could not find java version on given string " + version);
+		this.major = Integer.valueOf(matcher.group(1));
+		final String minorVersion = matcher.group(2);
+		this.minor = Integer.valueOf(StringUtils.isBlank(minorVersion) ? "0" : minorVersion);
+		this.version = Double.valueOf(String.format("%s.%s", major, minor));
 	}
 	
 	public boolean gte(JavaVersion version) {
-	    return this.major >= version.major && this.minor >= version.minor;
+		return Double.compare(this.version, version.version) > 0;
 	}
 	
 	public static JavaVersion current(){
@@ -27,16 +39,8 @@ public class JavaVersion {
 		return major;
 	}
 
-	public void setMajor(int major) {
-		this.major = major;
-	}
-
 	public int getMinor() {
 		return minor;
 	}
 
-	public void setMinor(int minor) {
-		this.minor = minor;
-	}
-	
 }

--- a/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
+++ b/src/main/java/br/com/six2six/fixturefactory/ObjectFactory.java
@@ -28,7 +28,7 @@ import br.com.six2six.fixturefactory.util.ReflectionUtils;
 import static br.com.six2six.fixturefactory.util.ReflectionUtils.hasDefaultConstructor;
 import static br.com.six2six.fixturefactory.util.ReflectionUtils.newInstance;
 
-public class ObjectFactory {
+public class ObjectFactory<T> {
 	
 	private static final String NO_SUCH_LABEL_MESSAGE = "%s-> No such label: %s";
 	private static final String LABELS_AMOUNT_DOES_NOT_MATCH = "%s-> labels amount does not match asked quantity (%s)";
@@ -57,30 +57,30 @@ public class ObjectFactory {
     }
     
 	@SuppressWarnings("unchecked")
-	public <T> T gimme(String label) {
+	public T gimme(String label) {
 		Rule rule = findRule(label);
 
 		return (T) this.createObject(rule);
 	}
 
 	@SuppressWarnings("unchecked")
-	public <T> T gimme(String label, Rule propertiesToOverride) {
+	public T gimme(String label, Rule propertiesToOverride) {
 		Rule rule = findRule(label);
 
 		return (T) this.createObject(new Rule(rule, propertiesToOverride));
 	}
 
-	public <T> List<T> gimme(Integer quantity, String label) {
+	public List<T> gimme(Integer quantity, String label) {
 		Rule rule = findRule(label);
 
 		return this.createObjects(quantity, rule);
 	}
 	
-	public <T> List<T> gimme(Integer quantity, String... labels) {
+	public List<T> gimme(Integer quantity, String... labels) {
 		return gimme(quantity, Arrays.asList(labels));
 	}
 	
-	public <T> List<T> gimme(Integer quantity, List<String> labels) {
+	public List<T> gimme(Integer quantity, List<String> labels) {
 		if(labels.size() != quantity) throw new IllegalArgumentException(String.format(LABELS_AMOUNT_DOES_NOT_MATCH, templateHolder.getClazz().getName(), StringUtils.join(labels, ",")));
 		
 		List<Rule> rules = findRules(labels);
@@ -88,7 +88,7 @@ public class ObjectFactory {
 		return createObjects(quantity, rules);
 	}
 
-	public <T> List<T> gimme(int quantity, String label, Rule propertiesToOverride) {
+	public List<T> gimme(int quantity, String label, Rule propertiesToOverride) {
 		Rule rule = findRule(label);
 
 		return this.createObjects(quantity, new Rule(rule, propertiesToOverride));
@@ -137,7 +137,7 @@ public class ObjectFactory {
 	}
 	
 	@SuppressWarnings("unchecked")
-	protected <T> List<T> createObjects(int quantity, Rule rule) {
+	protected List<T> createObjects(int quantity, Rule rule) {
 		List<T> results = new ArrayList<T>(quantity);
 		for (int i = 0; i < quantity; i++) {
 			results.add((T) this.createObject(rule));
@@ -147,7 +147,7 @@ public class ObjectFactory {
 	}
 	
 	@SuppressWarnings("unchecked")
-	protected <T> List<T> createObjects(int quantity, List<Rule> rules) {
+	protected List<T> createObjects(int quantity, List<Rule> rules) {
 		List<T> results = new ArrayList<T>(quantity);
 		for (int i = 0; i < quantity; i++) {
 			results.add((T) this.createObject(rules.get(i)));
@@ -192,7 +192,7 @@ public class ObjectFactory {
 		Map<String, Object> processedArguments = processArguments(arguments); 
 		
 		if (owner != null && ReflectionUtils.isInnerClass(templateHolder.getClazz()))  {
-			values.add(owner);	
+			values.add(owner);
 		}
 		
         TransformerChain transformerChain = buildTransformerChain(new ParameterPlaceholderTransformer(processedArguments));
@@ -241,7 +241,7 @@ public class ObjectFactory {
 		return transformerChain.transform(value, fieldType);
 	}
 	
-	protected <T> List<String> lookupConstructorParameterNames(Class<T> target, Set<Property> properties) {
+	protected List<String> lookupConstructorParameterNames(Class<?> target, Set<Property> properties) {
 		Collection<String> propertyNames = ReflectionUtils.map(properties, "rootAttribute");
 		return ReflectionUtils.filterConstructorParameters(target, propertyNames);
 	}

--- a/src/main/java/br/com/six2six/fixturefactory/loader/FixtureFactoryLoader.java
+++ b/src/main/java/br/com/six2six/fixturefactory/loader/FixtureFactoryLoader.java
@@ -8,7 +8,7 @@ public class FixtureFactoryLoader {
         for (Class<?> clazz : getClassesForPackage(basePackage)) {
             if (!clazz.isInterface() && TemplateLoader.class.isAssignableFrom(clazz)) {
                 try {
-                	((TemplateLoader) clazz.newInstance()).load();
+                	((TemplateLoader) clazz.getDeclaredConstructor().newInstance()).load();
                 } catch (Exception e) {
                     throw new RuntimeException(String.format("template %s not loaded", clazz.getName()), e);
                 }

--- a/src/test/java/br/com/six2six/fixturefactory/GenericsTypeInferTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/GenericsTypeInferTest.java
@@ -1,0 +1,27 @@
+package br.com.six2six.fixturefactory;
+
+import br.com.six2six.fixturefactory.loader.FixtureFactoryLoader;
+import br.com.six2six.fixturefactory.model.User;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class GenericsTypeInferTest {
+
+    @BeforeClass
+    public static void setUp() {
+        FixtureFactoryLoader.loadTemplates("br.com.six2six.template");
+    }
+
+    /**
+     * This will also be useful to work with java 11 var statement
+     */
+    @Test
+    public void shouldInferListType() {
+        validate(Arrays.asList(Fixture.from(User.class).gimme("validFemaleUser")));
+    }
+
+    private void validate(List<User> users) {}
+}

--- a/src/test/java/br/com/six2six/fixturefactory/JavaVersionTest.java
+++ b/src/test/java/br/com/six2six/fixturefactory/JavaVersionTest.java
@@ -1,0 +1,69 @@
+package br.com.six2six.fixturefactory;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class JavaVersionTest {
+
+	@Test
+	public void java6Parse(){
+
+		// arrange
+
+		// act
+		final JavaVersion javaVersion = new JavaVersion("1.6");
+
+		// assert
+		assertEquals(1, javaVersion.getMajor());
+		assertEquals(6, javaVersion.getMinor());
+	}
+
+	@Test
+	public void java11Parse(){
+
+		// arrange
+
+		// act
+		final JavaVersion javaVersion = new JavaVersion("11.0.1");
+
+		// assert
+		assertEquals(11, javaVersion.getMajor());
+		assertEquals(0, javaVersion.getMinor());
+	}
+
+	@Test
+	public void java12EarlierAccessParse(){
+
+		// arrange
+
+		// act
+		final JavaVersion javaVersion = new JavaVersion("12-ea");
+
+		// assert
+		assertEquals(12, javaVersion.getMajor());
+		assertEquals(0, javaVersion.getMinor());
+	}
+
+	@Test
+	public void java8ShouldBeGreaterThanJava6(){
+
+		// act
+		final boolean greater = JavaVersion.JAVA_8.gte(JavaVersion.JAVA_6);
+
+		// assert
+		assertTrue(greater);
+	}
+
+	@Test
+	public void java12ShouldBeGreaterThanJava8(){
+
+		// act
+		final boolean greater = new JavaVersion("12-ea").gte(JavaVersion.JAVA_6);
+
+		// assert
+		assertTrue(greater);
+	}
+
+}


### PR DESCRIPTION
* The use case is described at `GenericsTypeInferTest`
* Another use case is on java 11 where you can use `var` statement 

```java
var user = Fixture.from(User.class).gimme("validFemaleUser");
```
On Fixture `3.1.0` javac can not  make the inference and understand that user is a `User` instance
